### PR TITLE
context.doc to context.document

### DIFF
--- a/Tagged Layers/Tagged Layers.sketchplugin/Contents/Sketch/script.cocoascript
+++ b/Tagged Layers/Tagged Layers.sketchplugin/Contents/Sketch/script.cocoascript
@@ -26,7 +26,7 @@ var tagSelectedLayers = function(context) {
 var setTaggedLayersVisible = function(context, visible) {
   var selection = context.selection;    // An NSArray of MSLayers
   var command = context.command;        // The current command (MSPluginCommand)
-  var doc = context.doc;                // the current document (MSDocument)
+  var doc = context.document;                // the current document (MSDocument)
   var page = [doc currentPage];         // the current page (MSPage)
   var layers = [page children];         // A flattened array (NSArray) of all layers in `page`
   


### PR DESCRIPTION
Same as the last commit re: line 5 - example doesn't work unless line 29 is context.document.